### PR TITLE
Add pdfcols dependency

### DIFF
--- a/tools/pkgs-yihui.txt
+++ b/tools/pkgs-yihui.txt
@@ -102,6 +102,7 @@ ntgclass
 palatino
 parskip
 pbox
+pdfcol
 pdflscape
 pdfpages
 pdfsync


### PR DESCRIPTION
We'd like to add this to this version of TinyTeX so that Quarto documents won't by default require a package download (currently because we use tcolorbox, a fresh install of Quarto is requiring users to install pdfcol to compile a PDF). TY!