### PR TITLE
Add tikzfill

### DIFF
--- a/tools/pkgs-yihui.txt
+++ b/tools/pkgs-yihui.txt
@@ -142,6 +142,7 @@ thmtools
 threeparttable
 threeparttablex
 thumbpdf
+tikzfill
 titlesec
 totcount
 totpages


### PR DESCRIPTION
This adds tikzfill, which is used in Quarto as a part of our code annotation capability in 1.3. If you're ok with this, it will mean users who use the `quarto install tinytex` command will not need to download packages to render default Quarto documents.