### PR TITLE
Add windows to the list of platforms

### DIFF
--- a/R/tlmgr.R
+++ b/R/tlmgr.R
@@ -360,10 +360,11 @@ tl_platforms = function(print = FALSE) {
 
 # a copy of the returned result from tl_platform() is saved here because
 # tl_platform() is a little slow and requires Internet connection
+# also win32 (< TeX Live 2023) and windows (>= Tex Live 2023) are both added
 .tl_platforms = c(
   'aarch64-linux', 'amd64-freebsd', 'amd64-netbsd', 'armhf-linux', 'i386-cygwin',
   'i386-freebsd', 'i386-linux', 'i386-netbsd', 'i386-solaris', 'universal-darwin',
-  'win32', 'x86_64-cygwin', 'x86_64-darwinlegacy', 'x86_64-linux',
+  'windows', 'win32', 'x86_64-cygwin', 'x86_64-darwinlegacy', 'x86_64-linux',
   'x86_64-linuxmusl', 'x86_64-solaris'
 )
 

--- a/R/tlmgr.R
+++ b/R/tlmgr.R
@@ -360,11 +360,10 @@ tl_platforms = function(print = FALSE) {
 
 # a copy of the returned result from tl_platform() is saved here because
 # tl_platform() is a little slow and requires Internet connection
-# also win32 (< TeX Live 2023) and windows (>= Tex Live 2023) are both added
 .tl_platforms = c(
   'aarch64-linux', 'amd64-freebsd', 'amd64-netbsd', 'armhf-linux', 'i386-cygwin',
   'i386-freebsd', 'i386-linux', 'i386-netbsd', 'i386-solaris', 'universal-darwin',
-  'windows', 'win32', 'x86_64-cygwin', 'x86_64-darwinlegacy', 'x86_64-linux',
+  'windows', 'x86_64-cygwin', 'x86_64-darwinlegacy', 'x86_64-linux',
   'x86_64-linuxmusl', 'x86_64-solaris'
 )
 

--- a/R/tlmgr.R
+++ b/R/tlmgr.R
@@ -361,7 +361,7 @@ tl_platforms = function(print = FALSE) {
 # a copy of the returned result from tl_platform() is saved here because
 # tl_platform() is a little slow and requires Internet connection
 .tl_platforms = c(
-  'aarch64-linux', 'amd64-freebsd', 'amd64-netbsd', 'armhf-linux', 'i386-cygwin',
+  'aarch64-linux', 'amd64-freebsd', 'amd64-netbsd', 'armhf-linux',
   'i386-freebsd', 'i386-linux', 'i386-netbsd', 'i386-solaris', 'universal-darwin',
   'windows', 'x86_64-cygwin', 'x86_64-darwinlegacy', 'x86_64-linux',
   'x86_64-linuxmusl', 'x86_64-solaris'


### PR DESCRIPTION
@yihui The new list on Ubuntu gives me `windows`  and not `win32` 

````
> Rscript -e 'tinytex:::tl_platforms()'
 [1] "aarch64-linux"       "amd64-freebsd"       "amd64-netbsd"
 [4] "armhf-linux"         "i386-freebsd"        "i386-linux"
 [7] "i386-netbsd"         "i386-solaris"        "universal-darwin"
[10] "windows"             "x86_64-cygwin"       "x86_64-darwinlegacy"
[13] "x86_64-linux"        "x86_64-linuxmusl"    "x86_64-solaris"
````

Is this ok to store both here ? It is not exact result of `tl_platforms()` but I believe for its usage it will be ok. 

This will solve the failed CI job also

Related to https://github.com/rstudio/tinytex-releases/issues/36