### PR TITLE
Use shell() to execute the command if its path would be shortened by system2() on Windows

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: tinytex
 Type: Package
 Title: Helper Functions to Install and Maintain TeX Live, and Compile LaTeX Documents
-Version: 0.48.2
+Version: 0.48.3
 Authors@R: c(
   person("Yihui", "Xie", role = c("aut", "cre", "cph"), email = "xie@yihui.name", comment = c(ORCID = "0000-0003-0645-5666")),
   person(given = "Posit Software, PBC", role = c("cph", "fnd")),

--- a/R/utils.R
+++ b/R/utils.R
@@ -27,3 +27,17 @@ read_lines = function(...) {
   x[!validEnc(x)] = ''
   x
 }
+
+# for some reason, some TeX Live utilities refuse to work if they are called by
+# their short paths (#427), in which case we switch to shell()
+if (xfun::is_windows()) system2 = function(command, args, ...) {
+  if (length(list(...)) > 0 || !is_short(command)) {
+    base::system2(command, args, ...)
+  } else shell(paste(c(command, args), collapse = ' '))
+}
+
+# test if a path would be shortened on Windows
+is_short = function(x) {
+  x = Sys.which(x)
+  (x != '') && (normalizePath(x) != shortPathName(x))
+}


### PR DESCRIPTION
A hack to fix #427, but I'd prefer not having to resort to a hack like this.